### PR TITLE
Allow adding '/' as an unhandled path.

### DIFF
--- a/core/api.cfc
+++ b/core/api.cfc
@@ -522,6 +522,10 @@
 			</cfif>
 		</cfif>
 		<!--- translate unhandledPaths config to regex for easier matching (This is ripped off from FW/1. Thanks, Sean!) --->
+		<cfset local._taffy.settings.unhandledPathsContainsRoot= listContains(local._taffy.settings.unhandledPaths,'/')/>
+		<cfif local._taffy.settings.unhandledPathsContainsRoot>
+		        <cfset local._taffy.settings.unhandledPaths=listDeleteAt(local._taffy.settings.unhandledPaths,listFind(local._taffy.settings.unhandledPaths,'/'))/>
+		</cfif>
 		<cfset local._taffy.settings.unhandledPathsRegex = replaceNoCase(
 			REReplace(local._taffy.settings.unhandledPaths, '(\+|\*|\?|\.|\[|\^|\$|\(|\)|\{|\||\\)', '\\\1', 'all' ),
 			',', '|', 'all' )
@@ -1252,6 +1256,9 @@
 
 	<cffunction name="isUnhandledPathRequest" access="private" returntype="boolean">
 		<cfargument name="targetPath" />
+		<cfif application._taffy.settings.unhandledPathsContainsRoot and listLen(arguments.targetPath,'/') eq 1 >
+		        <cfreturn true>
+		</cfif>
 		<cfreturn REFindNoCase( "^(" & application._taffy.settings.unhandledPathsRegex & ")", arguments.targetPath ) />
 	</cffunction>
 


### PR DESCRIPTION
Have to special case the tests, because the regular expression that matches '/foo' will also match '/' if you give both in the unhandled path
